### PR TITLE
Clean up error messaging

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[flake8]
+max-line-length = 100
+exclude =
+  lib/biokbase,
+  submodules,
+  */prepare_deploy_cfg.py,
+  */NarrativeRunner_server_test.py,
+  test_scripts
+putty-ignore =
+    */__init__.py : F401,E126
+    *Impl.py : E265,E266
+    *Server.py : E265,E266
+    *Client.py : E265,E266


### PR DESCRIPTION
Clean up the way multiproc errors get printed for: https://kbase-jira.atlassian.net/browse/SCT-1133

The existing tests seem to run the same as before, and I did some manual testing. Let me know if this can get released on CI so I can test it.